### PR TITLE
Add v25.8.8.26-lts formula.

### DIFF
--- a/Formula/clickhouse@25.8.rb
+++ b/Formula/clickhouse@25.8.rb
@@ -1,0 +1,100 @@
+class ClickhouseAT258 < Formula
+  desc "Free analytics DBMS for big data with SQL interface"
+  homepage "https://clickhouse.com"
+  url "https://github.com/ClickHouse/ClickHouse/releases/download/v25.8.8.26-lts/clickhouse-macos-aarch64",
+      verified: "github.com/ClickHouse/ClickHouse/"
+  sha256 "e7c3ed9f2589decc7db7e59e1bc7946c2868899e16ce61be528c496fa7fbe7cb"
+  license "Apache-2.0"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+[._-](lts|stable))$/i)
+  end
+
+  def install
+    chmod "+x", "./clickhouse-macos-aarch64"
+    system(
+      "./clickhouse-macos-aarch64",
+      "install",
+      "--prefix",
+      HOMEBREW_PREFIX,
+      "--binary-path",
+      prefix/"bin",
+      "--user",
+      "",
+      "--group",
+      "",
+    )
+
+    # Relax the permissions when packaging.
+    Dir.glob([
+      etc/"clickhouse-server/**/*",
+      var/"run/clickhouse-server/**/*",
+      var/"log/clickhouse-server/**/*",
+    ]) do |file|
+      chmod 0664, file
+      chmod "a+x", file if File.directory?(file)
+    end
+  end
+
+  def post_install
+    # WORKAROUND: .../log/ dir is not bottled, looks like.
+    mkdir_p var/"log/clickhouse-server"
+
+    # Fix the permissions when deploying.
+    Dir.glob([
+      etc/"clickhouse-server/**/*",
+      var/"run/clickhouse-server/**/*",
+      var/"log/clickhouse-server/**/*",
+    ]) do |file|
+      chmod 0640, file
+      chmod "ug+x", file if File.directory?(file)
+    end
+
+    # Make sure the data directories are initialized.
+    system opt_bin/"clickhouse", "start", "--prefix", HOMEBREW_PREFIX, "--binary-path", opt_bin, "--user", ""
+    system opt_bin/"clickhouse", "stop", "--prefix", HOMEBREW_PREFIX
+  end
+
+  def caveats
+    <<~EOS
+      If you intend to run ClickHouse server:
+
+        - Familiarize yourself with the usage recommendations:
+            https://clickhouse.com/docs/en/operations/tips/
+
+        - Increase the maximum number of open files limit in the system:
+            macOS: https://clickhouse.com/docs/en/development/build-osx/#caveats
+            Linux: man limits.conf
+
+        - Set the 'net_admin', 'ipc_lock', and 'sys_nice' capabilities on #{opt_bin}/clickhouse binary. If the capabilities are not set the taskstats accounting will be disabled. You can enable taskstats accounting by setting those capabilities manually later.
+            Linux: sudo setcap 'cap_net_admin,cap_ipc_lock,cap_sys_nice+ep' #{opt_bin}/clickhouse
+
+        - By default, the pre-configured 'default' user has an empty password. Consider setting a real password for it:
+            https://clickhouse.com/docs/en/operations/settings/settings-users/
+
+        - By default, ClickHouse server is configured to listen for local connections only. Adjust 'listen_host' configuration parameter to allow wider range of addresses for incoming connections:
+            https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings/#server_configuration_parameters-listen_host
+    EOS
+  end
+
+  service do
+    run [
+      opt_bin/"clickhouse", "server",
+      "--config-file", etc/"clickhouse-server/config.xml",
+      "--pid-file", var/"run/clickhouse-server/clickhouse-server.pid"
+    ]
+    keep_alive true
+    run_type :immediate
+    process_type :standard
+    root_dir var
+    working_dir var
+    log_path var/"log/clickhouse-server/stdout.log"
+    error_log_path var/"log/clickhouse-server/stderr.log"
+  end
+
+  test do
+    assert_match "Denis Glazachev",
+      shell_output("#{bin}/clickhouse local --query 'SELECT * FROM system.contributors FORMAT TabSeparated'")
+  end
+end


### PR DESCRIPTION
Cursor prompt:

> Duplicate the most recent clickhouse formula file and replace `url` with `https://github.com/ClickHouse/ClickHouse/releases/download/v25.8.8.26-lts/clickhouse-macos-aarch64` and `sha256` with `e7c3ed9f2589decc7db7e59e1bc7946c2868899e16ce61be528c496fa7fbe7cb`
